### PR TITLE
Don't force ActionMailer to lazy load before configuration.

### DIFF
--- a/lib/railgun/railtie.rb
+++ b/lib/railgun/railtie.rb
@@ -2,8 +2,11 @@ require 'railgun/mailer'
 
 module Railgun
   class Railtie < ::Rails::Railtie
-    config.before_configuration do
-      ActionMailer::Base.add_delivery_method :mailgun, Railgun::Mailer
+    initializer "railgun.configure_rails_initialization" do
+      ActiveSupport.on_load(:action_mailer) do
+        add_delivery_method :mailgun, Railgun::Mailer
+        ActiveSupport.run_load_hooks(:mailgun_mailer, Railgun::Mailer)
+      end
     end
   end
 end


### PR DESCRIPTION
From [PR162](https://github.com/mailgun/mailgun-ruby/pull/162)