### PR TITLE
(Railgun) Add Ability To Configure All Options Through Rails Mailer

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -32,6 +32,8 @@ module Railgun
         config[:api_host] || 'api.mailgun.net',
         config[:api_version] || 'v3',
         config[:api_ssl].nil? ? true : config[:api_ssl],
+        config[:api_test_mode] || false,
+        config[:api_timeout]
       )
       @domain = @config[:domain]
 


### PR DESCRIPTION
This modification exposes two additional arguments that are available in
the initalize method of ::Mailgun::Client but not used by the
::Railgun::Mailer call. The changes provide access using the same
mechanism used to configure other mailer settings. The new settings
keys added are:

api_test_mode: [Boolean]
api_timeout: [Integer]

                      ,  ,
                 _  _ \`.)\  _  _
                __)\)`-)   )'|//(  ___
              _.--'     ___  `' <,',-\
             /,-._  ,\|'   `-._   `<_
               /_( (  _       `-.  <_`
              (.-_\/ _-.  )\     \ `.`_
             ,| / |:| \ \/  \     \ \<
           .';|/_O/;\_O\ |   \     \(\`
          / ; /  .'      |    \     `.
         / ; /__;__     /      ;
        /.' /" ;   "-. |       |
       /;   !  ;      `|       |
       |    \ O; O     |       ;  hjw
       \    ,\  ;     /\      /
        \ ,'  `._;_.-'  \   .'
         '               ),'